### PR TITLE
Enable deletions by digest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       environment:
         REGISTRY_HTTP_TLS_CERTIFICATE: /etc/pki/osbs-box/certs/domain.crt
         REGISTRY_HTTP_TLS_KEY: /etc/pki/osbs-box/certs/domain.key
+        REGISTRY_STORAGE_DELETE_ENABLED: "true"
         # REGISTRY_AUTH: htpasswd
         # REGISTRY_AUTH_HTPASSWD_PATH: /auth/htpasswd
         # REGISTRY_AUTH_HTPASSWD_REALM: Registry Realm


### PR DESCRIPTION
Enable deletion of images in the registry. This is useful to replicate
production behaviour when running Atomic Reactor's delete_from_registry
plugin. See https://docs.docker.com/registry/configuration/#delete for
reference.

Signed-off-by: Athos Ribeiro <athos@redhat.com>