### PR TITLE
Use skopeo-lite for copying images

### DIFF
--- a/base/Dockerfile.fedora
+++ b/base/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:27
+FROM registry.fedoraproject.org/fedora:29
 MAINTAINER Luiz Carvalho <lucarval@redhat.com>
 
 ARG UPDATES

--- a/client/Dockerfile.fedora
+++ b/client/Dockerfile.fedora
@@ -3,7 +3,7 @@ FROM osbs-box:fedora
 RUN dnf -y --refresh install \
       origin-clients \
       iproute \
-      koji-containerbuild-cli \
+      koji-containerbuild \
     && dnf clean all
 
 ADD bin/ /usr/local/bin/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
             - osbsbox-registry-auth:/auth
             - ./ssl:/etc/pki/osbs-box:z
 
+    skopeo-lite:
+      build: skopeo-lite
+      hostname: skopeo-lite
+
     koji-db:
         build: koji-db
         hostname: koji-db

--- a/skopeo-lite/Dockerfile
+++ b/skopeo-lite/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7
+
+ADD https://raw.githubusercontent.com/fedora-infra/bodhi/develop/bodhi/server/scripts/skopeo_lite.py /skopeo_lite.py
+RUN pip3 install click requests six
+
+ENTRYPOINT ["python3", "/skopeo_lite.py"]
+CMD []


### PR DESCRIPTION
Skopeo-lite copies images and creates manifest lists for all platforms.
For proper testing of osbs is desirable to having multiple platforms available.

New subcommand added: copy-image: copies image using skopeo-lite

Updated fedora base image to F29 due bodhi-skopeo-lite tool

Signed-off-by: Martin Bašti <mbasti@redhat.com>