### PR TITLE
Enable skip_koji_check_for_base_image by default

### DIFF
--- a/client/configs/reactor-config-map.yml
+++ b/client/configs/reactor-config-map.yml
@@ -54,3 +54,5 @@ required_secrets:
 
 worker_token_secrets:
 - client-config-secret
+
+skip_koji_check_for_base_image: True


### PR DESCRIPTION
Otherwise fedora-based builds will start failing when OSBS-7166 is done.