### PR TITLE
Disable check for base image koji build

### DIFF
--- a/client/configs/reactor-config-map.yml
+++ b/client/configs/reactor-config-map.yml
@@ -54,3 +54,5 @@ required_secrets:
 
 worker_token_secrets:
 - client-config-secret
+
+skip_koji_check_for_base_image: True


### PR DESCRIPTION
osbs-box injects a base image in the internal registry for test
purposes. We need to disable the atomic-reactor check that looks for a
koji build for the base image in order to use the injected one.